### PR TITLE
fix(webpack config): global object output setting

### DIFF
--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -10,6 +10,7 @@ module.exports = {
   output: {
     path: libPath,
     filename: "qr-code-styling.js",
+    globalObject: "this",
     library: "QRCodeStyling",
     libraryTarget: "umd",
     libraryExport: "default"


### PR DESCRIPTION
Implement PR from: https://github.com/kozakdenys/qr-code-styling/pull/64

> When targeting a library, especially when libraryTarget is 'umd', this option indicates what global object will be used to mount the library. To make UMD build available on both browsers and Node.js, set output.globalObject option to 'this'. Defaults to self for Web-like targets.